### PR TITLE
readme typo and cluster config persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ $ oc cluster up
 ``````
 $ oc cluster down
 ``````
+Note: By default, etcd data will not be preserved between container restarts.
+If you wish to preserve your data, specify a value for --host-data-dir and the
+--use-existing-config flag.
+
+
+Default routes are setup using xip.io and the host ip of your cluster. To use a
+different routing suffix, use the --routing-suffix flag.
 
 ## Advanced Testbed Environment
 

--- a/flume/README.md
+++ b/flume/README.md
@@ -189,7 +189,7 @@ $ oc logs bc/flume-service -f
 $ oc expose --hostname=flume.192.168.1.44.xip.io svc flume-service
 
 
-$ oc logs pod flume-service-1-7mmu0 -f
+$ oc logs flume-service-1-7mmu0 -f
 $ curl -X POST \
     -H 'Content-Type: application/json; charset=UTF-8' \
     -d '[{"headers":{"header.key":"header.value"}, "body":"hello world"}]' \  


### PR DESCRIPTION
oc cluster up & down with configuration persistence.

mkdir osedata
oc cluster up --host-config-dir=$HOME/osedata --host-data-dir=$HOME/osedata