### PR TITLE
docker-entrypoint need modify /opt/zookeeper/conf/zoo.cfg 

### DIFF
--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -43,7 +43,8 @@ RUN \
   mv /opt/zookeeper-${ZK_VERSION} /opt/zookeeper && \
   mkdir -p /tmp/zookeeper && \
   chmod g+w /tmp/zookeeper && \
-  chmod g+w /etc/hosts && \
+  chown root: /opt/zookeeper/conf && \
+  chmod g+w /opt/zookeeper/conf && \
   rm -f /tmp/zookeeper-*
 
 # Configure


### PR DESCRIPTION
docker-entrypoint need modify /opt/zookeeper/conf/zoo.cfg, we have to modify ownership of /opt/zookeeper/conf folder to root:root.